### PR TITLE
tcping_freehostinfo: don't pass NULL to freeaddrinfo()

### DIFF
--- a/tcping.c
+++ b/tcping.c
@@ -22,8 +22,11 @@ int tcping_gethostinfo(char *node, char *serv, int ai_family,
 
 void tcping_freehostinfo(struct hostinfo *hi)
 {
-    freeaddrinfo(hi->ai);
-    free(hi);
+    if (hi) {
+        if (hi->ai)
+            freeaddrinfo(hi->ai);
+        free(hi);
+    }
 }
 
 int tcping_socket(struct hostinfo *host)


### PR DESCRIPTION
According to the POSIX man page, "The freeaddrinfo() function shall free one or more addrinfo structures". Trying to free zero structures is a misuse of the interface.
tcping segfaults with musl libc if the name does not resolve. Fix this by checking if `hi->ai` is NULL before calling freeaddrinfo(). Checking whether `hi` is NULL is not strictly necessary, but it makes the library more robust.